### PR TITLE
Add vercel.json to set Node.js version to 22.x

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "nodeVersion": "22.x"
+}


### PR DESCRIPTION
Vercel discontinued Node.js 18.x, causing build failures.
Set nodeVersion to 22.x to fix deployment.

https://claude.ai/code/session_01LVq7GrnhjCSnu4o3D4ep4z